### PR TITLE
Make .dpm folder in home

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     docker:
       # specify the version
-      - image: circleci/golang:1.9
+      - image: circleci/golang:1.12
 
     #### TEMPLATE_NOTE: go expects specific checkout path representing url
     #### expecting it in the form of

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/JPZ13/dpm/internal/parser"
@@ -29,6 +30,9 @@ var installCmd = &cobra.Command{
 		err := os.RemoveAll(project.ProjectCmdPath)
 		utils.HandleFatalError(err)
 
+		err = maybeMakeDotDPMFolder()
+		utils.HandleFatalError(err)
+
 		err = os.MkdirAll(project.ProjectCmdPath, 0755)
 		utils.HandleFatalError(err)
 
@@ -40,6 +44,25 @@ var installCmd = &cobra.Command{
 		err = installYAMLPackages()
 		utils.HandleFatalError(err)
 	},
+}
+
+// maybeMakeDotDPMFolder ensures that there is a .dpm
+// folder in the home directory
+func maybeMakeDotDPMFolder() error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+
+	dpmFolder := filepath.Join(homeDir, project.DotDPMFolder)
+
+	ok, err := utils.DoesFileExist(dpmFolder)
+	if !ok {
+		os.MkdirAll(dpmFolder, utils.WriteMode)
+		return nil
+	}
+
+	return err
 }
 
 // installYAMLPackages writes bash scripts for

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -9,6 +9,8 @@ import (
 
 const (
 	configName = ".dpm-config.json"
+	// DotDPMFolder houses commands
+	DotDPMFolder = ".dpm"
 )
 
 // ProjectPath TODO: update

--- a/internal/utils/files.go
+++ b/internal/utils/files.go
@@ -6,6 +6,10 @@ import (
 	"os"
 )
 
+// WriteMode is the default
+// file/folder writing mode
+const WriteMode = 0755
+
 // DoesFileExist is a quick way to check if
 // a file is already in the filesystem
 func DoesFileExist(filename string) (bool, error) {


### PR DESCRIPTION
This PR:
- Makes a `.dpm` folder in the user's home directory

This will be used to house a Content Addressed Storage system where we will store information on aliasing rather than overriding the binaries