### PR TITLE
Replace home directory method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME := github.com/JPZ13/dpm
-GO := docker run -it --rm -v ${PWD}:/go/src/$(PKG_NAME) -w /go/src/$(PKG_NAME) -e GOOS -e GOARCH golang:1.7 go
+GO := docker run -it --rm -v ${PWD}:/go/src/$(PKG_NAME) -w /go/src/$(PKG_NAME) -e GOOS -e GOARCH golang:1.12 go
 GLIDE := docker run -it --rm -v ${PWD}:/run/context -w /run/context dockerepo/glide
 
 .PHONY: all clean binaries linux-binary mac-binary fmt glide-init glide-install glide-update

--- a/internal/project/activate.go
+++ b/internal/project/activate.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"io/ioutil"
+	"os"
 	"path"
 
 	"github.com/JPZ13/dpm/internal/utils"
@@ -24,7 +25,7 @@ func ActivateProject() error {
 // at $HOME/.dpm-config.json to determine
 // if the project is active
 func IsProjectActive() (bool, error) {
-	homeDir, err := getHomeDirectory()
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return false, err
 	}
@@ -64,7 +65,7 @@ func activateProjectInConfig(filename string) error {
 // makeConfigIfNotExist writes the config
 // if the file does not exist
 func makeConfigIfNotExist() (string, error) {
-	homeDir, err := getHomeDirectory()
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
 	}

--- a/internal/project/deactivate.go
+++ b/internal/project/deactivate.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"errors"
+	"os"
 	"path"
 
 	"github.com/JPZ13/dpm/internal/utils"
@@ -13,7 +14,7 @@ const (
 
 // DeactivateProject removes the project from the config json file
 func DeactivateProject() error {
-	homeDir, err := getHomeDirectory()
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return err
 	}

--- a/internal/project/utils.go
+++ b/internal/project/utils.go
@@ -3,7 +3,6 @@ package project
 import (
 	"encoding/json"
 	"io/ioutil"
-	"os/user"
 )
 
 func writeProjectTableToFile(projectTable map[string]bool, filename string) error {
@@ -28,13 +27,4 @@ func getProjectTable(filename string) (map[string]bool, error) {
 	}
 
 	return projectTable, nil
-}
-
-func getHomeDirectory() (string, error) {
-	usr, err := user.Current()
-	if err != nil {
-		return "", err
-	}
-
-	return usr.HomeDir, nil
 }


### PR DESCRIPTION
Go 1.12 gives a built in utility method for getting a [platform-agnostic home directory](https://golang.org/pkg/os/#UserHomeDir).

This  PR:
- Replaces the existing utility function to get the home directory with the built in one
- Upgrades the go version for compiling