### PR TITLE
[pathtable] Overwrite when setting values

### DIFF
--- a/internal/pathtable/set.go
+++ b/internal/pathtable/set.go
@@ -2,7 +2,6 @@ package pathtable
 
 import (
 	"encoding/json"
-	"os"
 
 	"github.com/JPZ13/dpm/internal/utils"
 )
@@ -15,20 +14,7 @@ func (c *client) Set(path string, info AliasInfo) error {
 		return err
 	}
 
-	// unmarshal any json at given path
-	aliases, err := getAliasInfoAtPath(digest)
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-
-	if aliases == nil {
-		aliases = []AliasInfo{}
-	}
-
-	// append to what is currently there
-	aliases = append(aliases, info)
-
-	bytes, err := json.Marshal(aliases)
+	bytes, err := json.Marshal(info)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR:

- removes the read file and append in the `Set` method of path-table

It is more in line with traditional hash table design