### PR TITLE
[pathtable] Change Get/Set to use ProjectInfo

### DIFF
--- a/internal/pathtable/client.go
+++ b/internal/pathtable/client.go
@@ -3,7 +3,7 @@ package pathtable
 // Client is the interface for pathtable methods
 type Client interface {
 	Get(path string) ([]AliasInfo, error)
-	Set(path string, info AliasInfo) error
+	Set(path string, info ProjectInfo) error
 }
 
 type client struct {

--- a/internal/pathtable/client.go
+++ b/internal/pathtable/client.go
@@ -2,7 +2,7 @@ package pathtable
 
 // Client is the interface for pathtable methods
 type Client interface {
-	Get(path string) ([]AliasInfo, error)
+	Get(path string) (*ProjectInfo, error)
 	Set(path string, info ProjectInfo) error
 }
 

--- a/internal/pathtable/client_test.go
+++ b/internal/pathtable/client_test.go
@@ -1,0 +1,18 @@
+package pathtable
+
+import "testing"
+
+func TestPathTableClient(t *testing.T) {
+	client := makeTestClient()
+
+	project := makeProjectInfo()
+	goAlias := makeGoAliasInfo()
+
+	project.Commands = append(project.Commands, goAlias)
+
+	testSet(t, client, project)
+
+	testGet(t, client, project)
+
+	removeTestLocationFile(t)
+}

--- a/internal/pathtable/get.go
+++ b/internal/pathtable/get.go
@@ -9,11 +9,12 @@ import (
 )
 
 // Get retrieves blobs given an input path
-func (c *client) Get(location string) ([]AliasInfo, error) {
+func (c *client) Get(location string) (*ProjectInfo, error) {
 	// bubble up path checking for matches in basedirectory
 	var digest string
+	var err error
 	for location != "/" {
-		digest, err := c.getDigestFromPath(location)
+		digest, err = c.getDigestFromPath(location)
 		if err != nil {
 			return nil, err
 		}
@@ -38,20 +39,20 @@ func (c *client) Get(location string) ([]AliasInfo, error) {
 		}
 	}
 
-	return getAliasInfoAtPath(digest)
+	return getProjectInfoAtPath(digest)
 }
 
-func getAliasInfoAtPath(location string) ([]AliasInfo, error) {
+func getProjectInfoAtPath(location string) (*ProjectInfo, error) {
 	bytes, err := utils.GetFileBytes(location)
 	if err != nil {
 		return nil, err
 	}
 
-	var aliases []AliasInfo
-	err = json.Unmarshal(bytes, &aliases)
+	var projectInfo ProjectInfo
+	err = json.Unmarshal(bytes, &projectInfo)
 	if err != nil {
 		return nil, err
 	}
 
-	return aliases, nil
+	return &projectInfo, nil
 }

--- a/internal/pathtable/get_test.go
+++ b/internal/pathtable/get_test.go
@@ -1,0 +1,13 @@
+package pathtable
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func testGet(t *testing.T, client Client, project ProjectInfo) {
+	info, err := client.Get(testLocation)
+	require.NoError(t, err)
+	require.Equal(t, project, *info)
+}

--- a/internal/pathtable/model.go
+++ b/internal/pathtable/model.go
@@ -7,3 +7,10 @@ type AliasInfo struct {
 	BinaryLocation string          `json:"binaryLocation"`
 	VolumeName     string          `json:"volumeName"`
 }
+
+// ProjectInfo holds configuration information
+// about a project
+type ProjectInfo struct {
+	IsActive bool        `json:"isActive"`
+	Commands []AliasInfo `json:"commands"`
+}

--- a/internal/pathtable/set.go
+++ b/internal/pathtable/set.go
@@ -8,7 +8,7 @@ import (
 
 // Set puts the blob at a hashed string
 // of the path within the base directory
-func (c *client) Set(path string, info AliasInfo) error {
+func (c *client) Set(path string, info ProjectInfo) error {
 	digest, err := c.getDigestFromPath(path)
 	if err != nil {
 		return err

--- a/internal/pathtable/set_test.go
+++ b/internal/pathtable/set_test.go
@@ -9,9 +9,12 @@ import (
 func TestSetAliasInfo(t *testing.T) {
 	client := makeTestClient()
 
+	project := makeProjectInfo()
 	goAlias := makeGoAliasInfo()
 
-	err := client.Set(testLocation, goAlias)
+	project.Commands = append(project.Commands, goAlias)
+
+	err := client.Set(testLocation, project)
 	require.NoError(t, err)
 
 	removeTestLocationFile(t)

--- a/internal/pathtable/set_test.go
+++ b/internal/pathtable/set_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSetAliasInfo(t *testing.T) {
+func TestSet(t *testing.T) {
 	client := makeTestClient()
 
 	project := makeProjectInfo()
@@ -16,6 +16,8 @@ func TestSetAliasInfo(t *testing.T) {
 
 	err := client.Set(testLocation, project)
 	require.NoError(t, err)
+
+	testGet(t, client, project)
 
 	removeTestLocationFile(t)
 }

--- a/internal/pathtable/set_test.go
+++ b/internal/pathtable/set_test.go
@@ -6,18 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSet(t *testing.T) {
-	client := makeTestClient()
-
-	project := makeProjectInfo()
-	goAlias := makeGoAliasInfo()
-
-	project.Commands = append(project.Commands, goAlias)
-
+func testSet(t *testing.T, client Client, project ProjectInfo) {
 	err := client.Set(testLocation, project)
 	require.NoError(t, err)
-
-	testGet(t, client, project)
-
-	removeTestLocationFile(t)
 }

--- a/internal/pathtable/test_utils.go
+++ b/internal/pathtable/test_utils.go
@@ -47,6 +47,13 @@ func makePythonAliasInfo() AliasInfo {
 	}
 }
 
+func makeProjectInfo() ProjectInfo {
+	return ProjectInfo{
+		IsActive: true,
+		Commands: []AliasInfo{},
+	}
+}
+
 func getTestDigestFromPath(t *testing.T, location string) string {
 	digest, err := utils.GetDigestJSONFilename(location)
 	require.NoError(t, err)


### PR DESCRIPTION
This PR:

- Makes a ProjectInfo struct that contains a list of aliases and a boolean for whether the project is active
- Changes the Get/Set methods to use ProjectInfo
- Re-structures the tests and adds a Get test