### PR TITLE
[utils] Handle nested directories when creating new

### DIFF
--- a/internal/utils/files.go
+++ b/internal/utils/files.go
@@ -58,7 +58,7 @@ func EnsureDirectoryForFile(location string) error {
 	_, err := os.Stat(directory)
 
 	if os.IsNotExist(err) {
-		return os.Mkdir(directory, WriteMode)
+		return os.MkdirAll(directory, WriteMode)
 	}
 
 	return err


### PR DESCRIPTION
This PR:

- Allows files to be nested in directories that don't exist when calling `EnsureDirectoryForFile`