### PR TITLE
[utils, pathtable, router] Refactor ensure directory

### DIFF
--- a/internal/pathtable/get.go
+++ b/internal/pathtable/get.go
@@ -10,9 +10,13 @@ import (
 
 // Get retrieves blobs given an input path
 func (c *client) Get(location string) (*ProjectInfo, error) {
+	err := c.ensureBaseDirectory()
+	if err != nil {
+		return nil, err
+	}
+
 	// bubble up path checking for matches in basedirectory
 	var digest string
-	var err error
 	for location != "/" {
 		digest, err = c.getDigestFromPath(location)
 		if err != nil {

--- a/internal/pathtable/set.go
+++ b/internal/pathtable/set.go
@@ -9,6 +9,11 @@ import (
 // Set puts the blob at a hashed string
 // of the path within the base directory
 func (c *client) Set(path string, info ProjectInfo) error {
+	err := c.ensureBaseDirectory()
+	if err != nil {
+		return err
+	}
+
 	digest, err := c.getDigestFromPath(path)
 	if err != nil {
 		return err

--- a/internal/pathtable/utils.go
+++ b/internal/pathtable/utils.go
@@ -15,3 +15,7 @@ func (c *client) getDigestFromPath(location string) (string, error) {
 	fullPath := path.Join(c.baseDirectory, digest)
 	return fullPath, nil
 }
+
+func (c *client) ensureBaseDirectory() error {
+	return utils.EnsureDirectory(c.baseDirectory)
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1,11 +1,5 @@
 package router
 
-import (
-	"os"
-
-	"github.com/JPZ13/dpm/internal/utils"
-)
-
 // Router holds public methods for a router
 type Router interface {
 	Has(alias string) (bool, error)
@@ -21,13 +15,4 @@ func NewRouter(config *Config) Router {
 	return &router{
 		baseDirectory: config.BaseDirectory,
 	}
-}
-
-func (r *router) ensureBaseDirectory() error {
-	doesExist, err := utils.DoesFileExist(r.baseDirectory)
-	if !doesExist {
-		return os.MkdirAll(r.baseDirectory, utils.WriteMode)
-	}
-
-	return err
 }

--- a/internal/router/utils.go
+++ b/internal/router/utils.go
@@ -1,7 +1,15 @@
 package router
 
-import "path"
+import (
+	"path"
+
+	"github.com/JPZ13/dpm/internal/utils"
+)
 
 func (r *router) getAliasPath(alias string) string {
 	return path.Join(r.baseDirectory, alias)
+}
+
+func (r *router) ensureBaseDirectory() error {
+	return utils.EnsureDirectory(r.baseDirectory)
 }

--- a/internal/utils/files.go
+++ b/internal/utils/files.go
@@ -55,10 +55,16 @@ func WriteFileBytes(filename string, bytes []byte) error {
 // if it does not exist
 func EnsureDirectoryForFile(location string) error {
 	directory := path.Dir(location)
-	_, err := os.Stat(directory)
+	return EnsureDirectory(directory)
+}
+
+// EnsureDirectory creates a directory if one does
+// not exist
+func EnsureDirectory(folderLocation string) error {
+	_, err := os.Stat(folderLocation)
 
 	if os.IsNotExist(err) {
-		return os.MkdirAll(directory, WriteMode)
+		return os.MkdirAll(folderLocation, WriteMode)
 	}
 
 	return err


### PR DESCRIPTION
This PR:

- Refactors `ensureBaseDirectory` into a utility function to `EnsureDirectory`
- Has `ensureBaseDirectory` in `pathtable` and `router` call `utils.EnsureDirectory`
- Calls `ensureBaseDirectory` at the beginning of each of the exported methods on `pathtable` and `router`

This ensures that the configuration is set and keeps me from having have any activate or isActive type logic.