### PR TITLE
[cmd] Start deprecating old activate logic

### DIFF
--- a/cmd/activate.go
+++ b/cmd/activate.go
@@ -1,20 +1,11 @@
 package cmd
 
 import (
-	"fmt"
-
-	"github.com/JPZ13/dpm/internal/alias"
-	"github.com/JPZ13/dpm/internal/project"
-	"github.com/JPZ13/dpm/internal/shell"
-	"github.com/JPZ13/dpm/internal/utils"
+	"github.com/JPZ13/dpm/cmd/activate"
 	"github.com/spf13/cobra"
 )
 
-var forceActivate bool
-
 func init() {
-	activateCmd.Flags().BoolVarP(&forceActivate, "force", "f", false,
-		"Force activation even if another project is currently active")
 	RootCmd.AddCommand(activateCmd)
 }
 
@@ -22,20 +13,6 @@ var activateCmd = &cobra.Command{
 	Use:   "activate",
 	Short: "Activates the project in the current shell",
 	Run: func(cmd *cobra.Command, args []string) {
-		if !project.IsProjectInstalled() {
-			err := installYAMLPackages()
-			utils.HandleFatalError(err)
-		}
-
-		err := project.ActivateProject()
-		utils.HandleFatalError(err)
-
-		err = alias.SetAliases()
-		utils.HandleFatalError(err)
-
-		err = shell.StartShell(shell.Activate)
-		utils.HandleFatalError(err)
-
-		fmt.Printf("Project '%s' activated\n", project.ProjectName)
+		activate.LegacyActivateCommand()
 	},
 }

--- a/cmd/activate/legacy.go
+++ b/cmd/activate/legacy.go
@@ -1,0 +1,32 @@
+package activate
+
+import (
+	"fmt"
+
+	"github.com/JPZ13/dpm/cmd/install"
+	"github.com/JPZ13/dpm/internal/alias"
+	"github.com/JPZ13/dpm/internal/project"
+	"github.com/JPZ13/dpm/internal/shell"
+	"github.com/JPZ13/dpm/internal/utils"
+)
+
+// LegacyActivateCommand is the old activate command
+// it is to be removed when the new activate logic
+// is put in place
+func LegacyActivateCommand() {
+	if !project.IsProjectInstalled() {
+		err := install.YAMLPackages()
+		utils.HandleFatalError(err)
+	}
+
+	err := project.ActivateProject()
+	utils.HandleFatalError(err)
+
+	err = alias.SetAliases()
+	utils.HandleFatalError(err)
+
+	err = shell.StartShell(shell.Activate)
+	utils.HandleFatalError(err)
+
+	fmt.Printf("Project '%s' activated\n", project.ProjectName)
+}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -58,8 +58,7 @@ func maybeMakeDotDPMFolder() error {
 
 	ok, err := utils.DoesFileExist(dpmFolder)
 	if !ok {
-		os.MkdirAll(dpmFolder, utils.WriteMode)
-		return nil
+		return os.MkdirAll(dpmFolder, utils.WriteMode)
 	}
 
 	return err

--- a/cmd/install/legacy.go
+++ b/cmd/install/legacy.go
@@ -1,0 +1,72 @@
+package install
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path"
+	"strings"
+
+	"github.com/JPZ13/dpm/internal/parser"
+	"github.com/JPZ13/dpm/internal/project"
+	"github.com/JPZ13/dpm/internal/utils"
+)
+
+// YAMLPackages writes bash scripts for
+// each of the commands listed in the dpm.yml file
+func YAMLPackages() error {
+	commands := parser.GetCommands(project.ProjectFilePath)
+	data, err := ioutil.ReadFile(project.ProjectFilePath)
+	utils.HandleFatalError(err)
+
+	// TODO: figure out what this is used for
+	err = ioutil.WriteFile(path.Join(project.ProjectCmdPath, "dpm.yml"), data, 0644)
+	utils.HandleFatalError(err)
+
+	fmt.Printf("Installing %d commands...\n", len(commands))
+
+	commandNames := []string{}
+
+	for name, command := range commands {
+		commandNames = append(commandNames, name)
+		cliCommands := commandToDockerCLIs(command)
+		err = writeDockerBashCommands(cliCommands)
+		utils.HandleFatalError(err)
+	}
+
+	fmt.Printf("Installed: %s\n", strings.Join(commandNames, ", "))
+
+	fmt.Print("Now you can run `dpm activate` to start using your new commands\n")
+
+	return nil
+}
+
+// writeDockerBashCommands :
+func writeDockerBashCommands(cliCommands map[string]string) error {
+	for entrypoint, bashCommand := range cliCommands {
+		targetPath := path.Join(project.ProjectCmdPath, entrypoint)
+		contents := fmt.Sprintf("#!/bin/sh\nexec %s", bashCommand)
+
+		err := ioutil.WriteFile(targetPath, []byte(contents), 0755)
+		utils.HandleFatalError(err)
+	}
+
+	return nil
+}
+
+// commandToDockerCLIs takes a command and translates it into
+// a docker cli command. It returns a map of the entrypoint to the
+// docker command
+func commandToDockerCLIs(command parser.Command) map[string]string {
+	volumes := ""
+	for _, volume := range command.Volumes {
+		volumes = fmt.Sprintf("%s -v %s", volumes, volume)
+	}
+
+	cliCommands := make(map[string]string)
+	for _, entrypoint := range command.Entrypoints {
+		cliCommands[entrypoint] = fmt.Sprintf("docker run -it --rm -v $(pwd):%s %s -w %s --entrypoint %s %s \"$@\"",
+			command.Context, volumes, command.Context, entrypoint, command.Image)
+	}
+
+	return cliCommands
+}


### PR DESCRIPTION
This PR:

- Moves the activate command's logic into a package within cmd
- Puts the old logic in a `LegacyActivateCommand` function
- Moves necessary install logic into a package within cmd

The subsequent PRs will follow the same route for all the old command logic