### PR TITLE
[cmd] Start deprecating old install logic

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -1,17 +1,7 @@
 package cmd
 
 import (
-	"fmt"
-	"io/ioutil"
-	"log"
-	"os"
-	"path"
-	"path/filepath"
-	"strings"
-
-	"github.com/JPZ13/dpm/internal/parser"
-	"github.com/JPZ13/dpm/internal/project"
-	"github.com/JPZ13/dpm/internal/utils"
+	"github.com/JPZ13/dpm/cmd/install"
 	"github.com/spf13/cobra"
 )
 
@@ -23,111 +13,6 @@ var installCmd = &cobra.Command{
 	Use:   "install",
 	Short: "Installs all commands defined in dpm.yml in the current project",
 	Run: func(cmd *cobra.Command, args []string) {
-		if !project.IsProjectInitialized() {
-			log.Fatal("error: no `dpm.yml` file found\n")
-		}
-
-		err := os.RemoveAll(project.ProjectCmdPath)
-		utils.HandleFatalError(err)
-
-		err = maybeMakeDotDPMFolder()
-		utils.HandleFatalError(err)
-
-		err = os.MkdirAll(project.ProjectCmdPath, 0755)
-		utils.HandleFatalError(err)
-
-		if len(args) > 0 {
-			err = installListedPackages(args)
-			utils.HandleFatalError(err)
-		}
-
-		err = installYAMLPackages()
-		utils.HandleFatalError(err)
+		install.LegacyInstallCommand(args)
 	},
-}
-
-// maybeMakeDotDPMFolder ensures that there is a .dpm
-// folder in the home directory
-func maybeMakeDotDPMFolder() error {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return err
-	}
-
-	dpmFolder := filepath.Join(homeDir, project.DotDPMFolder)
-
-	ok, err := utils.DoesFileExist(dpmFolder)
-	if !ok {
-		return os.MkdirAll(dpmFolder, utils.WriteMode)
-	}
-
-	return err
-}
-
-// installYAMLPackages writes bash scripts for
-// each of the commands listed in the dpm.yml file
-func installYAMLPackages() error {
-	commands := parser.GetCommands(project.ProjectFilePath)
-	data, err := ioutil.ReadFile(project.ProjectFilePath)
-	utils.HandleFatalError(err)
-
-	// TODO: figure out what this is used for
-	err = ioutil.WriteFile(path.Join(project.ProjectCmdPath, "dpm.yml"), data, 0644)
-	utils.HandleFatalError(err)
-
-	fmt.Printf("Installing %d commands...\n", len(commands))
-
-	commandNames := []string{}
-
-	for name, command := range commands {
-		commandNames = append(commandNames, name)
-		cliCommands := commandToDockerCLIs(command)
-		err = writeDockerBashCommands(cliCommands)
-		utils.HandleFatalError(err)
-	}
-
-	fmt.Printf("Installed: %s\n", strings.Join(commandNames, ", "))
-
-	fmt.Print("Now you can run `dpm activate` to start using your new commands\n")
-
-	return nil
-}
-
-// installListedPackages adds packages listed after
-// install on the CLI to the dpm.yml file
-func installListedPackages(packages []string) error {
-	commands := parser.GetCommandsFromCLI(packages)
-
-	return parser.AddCommands(project.ProjectFilePath, commands)
-}
-
-// commandToDockerCLIs takes a command and translates it into
-// a docker cli command. It returns a map of the entrypoint to the
-// docker command
-func commandToDockerCLIs(command parser.Command) map[string]string {
-	volumes := ""
-	for _, volume := range command.Volumes {
-		volumes = fmt.Sprintf("%s -v %s", volumes, volume)
-	}
-
-	cliCommands := make(map[string]string)
-	for _, entrypoint := range command.Entrypoints {
-		cliCommands[entrypoint] = fmt.Sprintf("docker run -it --rm -v $(pwd):%s %s -w %s --entrypoint %s %s \"$@\"",
-			command.Context, volumes, command.Context, entrypoint, command.Image)
-	}
-
-	return cliCommands
-}
-
-// writeDockerBashCommands :
-func writeDockerBashCommands(cliCommands map[string]string) error {
-	for entrypoint, bashCommand := range cliCommands {
-		targetPath := path.Join(project.ProjectCmdPath, entrypoint)
-		contents := fmt.Sprintf("#!/bin/sh\nexec %s", bashCommand)
-
-		err := ioutil.WriteFile(targetPath, []byte(contents), 0755)
-		utils.HandleFatalError(err)
-	}
-
-	return nil
 }

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/JPZ13/dpm/cmd/install"
 	"github.com/JPZ13/dpm/internal/parser"
 	"github.com/JPZ13/dpm/internal/project"
 	"github.com/JPZ13/dpm/internal/utils"
@@ -31,7 +32,7 @@ var uninstallCmd = &cobra.Command{
 			err := uninstallListedPackages(args)
 			utils.HandleFatalError(err)
 
-			err = installYAMLPackages()
+			err = install.YAMLPackages()
 			utils.HandleFatalError(err)
 		}
 	},


### PR DESCRIPTION
This PR:

- Moves the old install logic to a package within cmd

The goal is to deprecate the command logic and replace with the new pathtable/router set up