### PR TITLE
[cmd] Move old deactivate to allow deprecating

### DIFF
--- a/cmd/deactivate.go
+++ b/cmd/deactivate.go
@@ -1,20 +1,11 @@
 package cmd
 
 import (
-	"fmt"
-
-	"github.com/JPZ13/dpm/internal/alias"
-	"github.com/JPZ13/dpm/internal/project"
-	"github.com/JPZ13/dpm/internal/shell"
-	"github.com/JPZ13/dpm/internal/utils"
+	"github.com/JPZ13/dpm/cmd/deactivate"
 	"github.com/spf13/cobra"
 )
 
-var forceDeactivate bool
-
 func init() {
-	deactivateCmd.Flags().BoolVarP(&forceDeactivate, "force", "f", false,
-		"Force deactivation even if another project is currently active")
 	RootCmd.AddCommand(deactivateCmd)
 }
 
@@ -22,15 +13,6 @@ var deactivateCmd = &cobra.Command{
 	Use:   "deactivate",
 	Short: "Deactivates the project in the current shell",
 	Run: func(cmd *cobra.Command, args []string) {
-		err := project.DeactivateProject()
-		utils.HandleFatalError(err)
-
-		err = alias.UnsetAliases()
-		utils.HandleFatalError(err)
-
-		err = shell.StartShell(shell.Deactivate)
-		utils.HandleFatalError(err)
-
-		fmt.Printf("Project '%s' deactivated\n", project.ProjectName)
+		deactivate.LegacyDeactivateCommand()
 	},
 }

--- a/cmd/deactivate/legacy.go
+++ b/cmd/deactivate/legacy.go
@@ -1,0 +1,25 @@
+package deactivate
+
+import (
+	"fmt"
+
+	"github.com/JPZ13/dpm/internal/alias"
+	"github.com/JPZ13/dpm/internal/project"
+	"github.com/JPZ13/dpm/internal/shell"
+	"github.com/JPZ13/dpm/internal/utils"
+)
+
+// LegacyDeactivateCommand holds the old
+// deactivate logic that is being deprecated
+func LegacyDeactivateCommand() {
+	err := project.DeactivateProject()
+	utils.HandleFatalError(err)
+
+	err = alias.UnsetAliases()
+	utils.HandleFatalError(err)
+
+	err = shell.StartShell(shell.Deactivate)
+	utils.HandleFatalError(err)
+
+	fmt.Printf("Project '%s' deactivated\n", project.ProjectName)
+}


### PR DESCRIPTION
This PR:

- Moves the old deactivate logic to a package in cmd to allow easier deprecation