### PR TITLE
[core][pathtable] Handle out of project commands

### DIFF
--- a/internal/core/run.go
+++ b/internal/core/run.go
@@ -68,14 +68,21 @@ func runBinaryFromPATH(args []string) error {
 		doesExist, _ := utils.DoesFileExist(binaryPath)
 		if doesExist {
 			remainder := args[1:]
-			command := exec.Command(binaryPath, remainder...)
-			command.Stdout = os.Stdout
-			command.Stderr = os.Stderr
-			return command.Run()
+			return runShellCommand(binaryPath, remainder...)
 		}
 	}
 
 	return errors.New("command not found")
+}
+
+// runShellCommand is a helper function for running commands
+// on the terminal
+func runShellCommand(cmdName string, args ...string) error {
+	command := exec.Command(cmdName, args...)
+	command.Stdin = os.Stdin
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	return command.Run()
 }
 
 // callBinary calls the stored binary of an alias
@@ -90,8 +97,7 @@ func callBinary(args []string, project *model.ProjectInfo) error {
 			}
 
 			// execute command of binary and remainder
-			cmd := exec.Command(binaryPath, remainder...)
-			return cmd.Run()
+			return runShellCommand(binaryPath, remainder...)
 		}
 	}
 

--- a/internal/pathtable/get.go
+++ b/internal/pathtable/get.go
@@ -9,6 +9,9 @@ import (
 	"github.com/JPZ13/dpm/internal/utils"
 )
 
+// ErrNotFound signals that the project was not found
+var ErrNotFound = errors.New("Project info file not found")
+
 // Get retrieves blobs given an input path
 func (c *client) Get(location string) (*model.ProjectInfo, error) {
 	err := c.ensureBaseDirectory()
@@ -40,7 +43,7 @@ func (c *client) Get(location string) (*model.ProjectInfo, error) {
 
 		hasFile, _ := utils.DoesFileExist(digest)
 		if !hasFile {
-			return nil, errors.New("Alias info file not found")
+			return nil, ErrNotFound
 		}
 	}
 


### PR DESCRIPTION
This PR:

- Adds a not found error to the pathtable package
- Adds logic to the core package to scan the user's PATH to find and run a command if it is not found using the pathtable