### PR TITLE
[core] Append latest when no image tag specified

### DIFF
--- a/internal/core/run.go
+++ b/internal/core/run.go
@@ -245,6 +245,8 @@ func pullImageIfNotInDockerHost(dockerClient *docker.Client, imageName string) e
 		return err
 	}
 
+	imageName = ensureImageTag(imageName)
+
 	// don't pull if image already in host
 	for _, image := range images {
 		for _, repoTag := range image.RepoTags {
@@ -282,4 +284,13 @@ func stopAndRemoveContainer(dockerClient *docker.Client, containerID string) err
 		RemoveLinks:   false,
 		Force:         false,
 	})
+}
+
+func ensureImageTag(imageName string) string {
+	if strings.Contains(imageName, ":") {
+		return imageName
+	}
+
+	image := []string{imageName, "latest"}
+	return strings.Join(image, ":")
 }

--- a/internal/core/run_test.go
+++ b/internal/core/run_test.go
@@ -1,0 +1,18 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureImageTag(t *testing.T) {
+	t.Parallel()
+
+	image := ensureImageTag("golang")
+	require.Equal(t, "golang:latest", image)
+
+	pythonAlpine := "python:alpine"
+	withTag := ensureImageTag(pythonAlpine)
+	require.Equal(t, pythonAlpine, withTag)
+}


### PR DESCRIPTION
This PR:

- Adds a function that appends `:latest` if a tag isn't specified when looking up images on the docker host
- Writes a test