### PR TITLE
[cmd] Ignore flags

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -17,9 +17,6 @@ func init() {
 var RootCmd = &cobra.Command{
 	Use:   "dpm",
 	Short: "Install development tools locally to your project using docker containers",
-	FParseErrWhitelist: cobra.FParseErrWhitelist{
-		UnknownFlags: true,
-	},
 }
 
 var activateCmd = &cobra.Command{

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -17,6 +17,9 @@ func init() {
 var RootCmd = &cobra.Command{
 	Use:   "dpm",
 	Short: "Install development tools locally to your project using docker containers",
+	FParseErrWhitelist: cobra.FParseErrWhitelist{
+		UnknownFlags: true,
+	},
 }
 
 var activateCmd = &cobra.Command{
@@ -38,6 +41,9 @@ var deactivateCmd = &cobra.Command{
 var runCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Run an alias that is defined in the dpm yaml file",
+	FParseErrWhitelist: cobra.FParseErrWhitelist{
+		UnknownFlags: true,
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		run.Command(args)
 	},

--- a/dpm.yml
+++ b/dpm.yml
@@ -5,7 +5,7 @@ commands:
       - glide
     volume_name: glide
   go:
-    image: golang:1.7.5
+    image: golang:1.12.9
     entrypoints:
       - go
     volume_name: go

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/pkg/errors v0.8.1 // indirect
 	github.com/sirupsen/logrus v1.4.2 // indirect
 	github.com/spf13/cobra v0.0.5
+	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.4.0
 	google.golang.org/grpc v1.23.0 // indirect
 	gopkg.in/yaml.v2 v2.2.2


### PR DESCRIPTION
This PR:
- Tells cobra to ignore flags on the run command

Note: to get cobra/pflag to still include flags that are passed to commands, I have to submit a PR to the [pflag repo](https://github.com/spf13/pflag/pull/160)