### PR TITLE
[internal] Generate hashes for volume names

### DIFF
--- a/dpm.yml
+++ b/dpm.yml
@@ -3,15 +3,12 @@ commands:
     image: dockerepo/glide:latest
     entrypoints:
       - glide
-    volume_name: glide
   go:
     image: golang:1.12.9
     entrypoints:
       - go
-    volume_name: go
   python:
     image: python:latest
     entrypoints:
       - python
       - pip
-    volume_name: python

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,7 @@ google.golang.org/grpc v1.22.0 h1:J0UbZOIrCAl+fpTOf8YLs4dJo8L/owV4LYVtAXQoPkw=
 google.golang.org/grpc v1.22.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.23.0 h1:AzbTB6ux+okLTzP8Ru1Xs41C303zdcfEht7MQnYJt5A=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/core/project.go
+++ b/internal/core/project.go
@@ -6,6 +6,7 @@ import (
 	"path"
 
 	"github.com/JPZ13/dpm/internal/model"
+	"github.com/JPZ13/dpm/internal/utils"
 	"gopkg.in/yaml.v2"
 )
 
@@ -29,18 +30,23 @@ func (p *project) InstallProject(ctx context.Context, dpmFileLocation string) er
 		return err
 	}
 
+	dpmDir := path.Dir(dpmFileLocation)
+	digest, err := utils.GetDigestJSONFilename(dpmDir)
+	if err != nil {
+		return err
+	}
+
 	// translate to project info
-	projectInfo, err := translateDPMFileToProjectInfo(dpmFile)
+	projectInfo, err := translateDPMFileToProjectInfo(dpmFile, digest)
 	if err != nil {
 		return err
 	}
 
 	projectInfo.IsActive = true
 
-	// set project info
-	dpmDir := path.Dir(dpmFileLocation)
 	projectInfo.Directory = dpmDir
 
+	// set project info
 	err = p.pathTable.Set(dpmDir, projectInfo)
 	if err != nil {
 		return err

--- a/internal/core/project.go
+++ b/internal/core/project.go
@@ -39,6 +39,7 @@ func (p *project) InstallProject(ctx context.Context, dpmFileLocation string) er
 
 	// set project info
 	dpmDir := path.Dir(dpmFileLocation)
+	projectInfo.Directory = dpmDir
 
 	err = p.pathTable.Set(dpmDir, projectInfo)
 	if err != nil {

--- a/internal/core/run.go
+++ b/internal/core/run.go
@@ -17,6 +17,7 @@ import (
 	"github.com/JPZ13/dpm/internal/utils"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/volume"
 	docker "github.com/docker/docker/client"
 )
@@ -113,27 +114,27 @@ func runDockerizedCommand(args []string, project *model.ProjectInfo) error {
 			if alias != command {
 				continue
 			}
-			return runDocker(args, &aliasInfo)
+			return runDocker(args, &aliasInfo, project.Directory)
 		}
 	}
 
 	return errors.New("Project error: alias not found")
 }
 
-func runDocker(args []string, alias *model.AliasInfo) error {
+func runDocker(args []string, alias *model.AliasInfo, projectDirectory string) error {
 	dockerClient, err := docker.NewEnvClient()
 	if err != nil {
 		return err
 	}
 
 	// create named volume if it doesn't exist
-	volume, err := maybeCreateVolume(dockerClient, alias.VolumeName)
+	volume, err := maybeCreateVolume(dockerClient, alias.VolumeName, projectDirectory)
 	if err != nil {
 		return err
 	}
 
 	// run volume mounted container container
-	container, err := runContainer(dockerClient, alias.Image, volume)
+	container, err := runContainer(dockerClient, alias.Image, projectDirectory, volume)
 	if err != nil {
 		return err
 	}
@@ -179,18 +180,25 @@ func attachToContainer(dockerClient *docker.Client, container *container.Contain
 	return err
 }
 
-func maybeCreateVolume(dockerClient *docker.Client, volumeName string) (*types.Volume, error) {
-	pwd, err := os.Getwd()
+func maybeCreateVolume(dockerClient *docker.Client, volumeName, projectDirectory string) (*types.Volume, error) {
+	ctx := context.Background()
+
+	volumeList, err := dockerClient.VolumeList(ctx, filters.Args{})
 	if err != nil {
 		return nil, err
 	}
 
-	ctx := context.Background()
+	for _, volume := range volumeList.Volumes {
+		if volume.Name == volumeName {
+			return volume, nil
+		}
+	}
+
 	volume, err := dockerClient.VolumeCreate(ctx, volume.VolumeCreateBody{
 		Driver: "local",
 		DriverOpts: map[string]string{
 			"type":   "none",
-			"device": pwd,
+			"device": projectDirectory,
 			"o":      "bind",
 		},
 		Name: volumeName,
@@ -202,7 +210,7 @@ func maybeCreateVolume(dockerClient *docker.Client, volumeName string) (*types.V
 	return &volume, nil
 }
 
-func runContainer(dockerClient *docker.Client, imageName string, volume *types.Volume) (*container.ContainerCreateCreatedBody, error) {
+func runContainer(dockerClient *docker.Client, imageName, projectDirectory string, volume *types.Volume) (*container.ContainerCreateCreatedBody, error) {
 	pwd, err := os.Getwd()
 	if err != nil {
 		return nil, err
@@ -214,6 +222,8 @@ func runContainer(dockerClient *docker.Client, imageName string, volume *types.V
 	}
 
 	ctx := context.Background()
+	// bind wherever the dpm file is but use current wd on host
+	// as container wd
 	container, err := dockerClient.ContainerCreate(ctx, &container.Config{
 		Image:        imageName,
 		Tty:          true,
@@ -223,7 +233,7 @@ func runContainer(dockerClient *docker.Client, imageName string, volume *types.V
 		WorkingDir:   pwd,
 	}, &container.HostConfig{
 		Binds: []string{
-			fmt.Sprintf("%s:%s", volume.Name, pwd),
+			fmt.Sprintf("%s:%s", volume.Name, projectDirectory),
 		},
 	}, nil, "")
 	if err != nil {

--- a/internal/core/test-data/dpm.yml
+++ b/internal/core/test-data/dpm.yml
@@ -3,15 +3,12 @@ commands:
     image: dockerepo/glide
     entrypoints:
       - glide
-    context: /run/context
   go:
     image: golang:1.7.5
     entrypoints:
       - go
-    context: /go/src/github.com/JPZ13/dpm
   python:
     image: python:latest
     entrypoints:
       - python
       - pip
-    context: /run/context

--- a/internal/core/translate_test.go
+++ b/internal/core/translate_test.go
@@ -1,9 +1,11 @@
 package core
 
 import (
+	"path"
 	"testing"
 
 	"github.com/JPZ13/dpm/internal/model"
+	"github.com/JPZ13/dpm/internal/utils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,7 +21,11 @@ func TestTranslateDPMFileToProjectInfo(t *testing.T) {
 	testDPMFile := makeTestDPMFile()
 	require.Equal(t, *testDPMFile, *dpmFile)
 
-	projectInfo, err := translateDPMFileToProjectInfo(dpmFile)
+	dpmDir := path.Dir(testDPMFileLocation)
+	digest, err := utils.GetDigestJSONFilename(dpmDir)
+	require.NoError(t, err)
+
+	projectInfo, err := translateDPMFileToProjectInfo(dpmFile, digest)
 	require.NoError(t, err)
 	require.NotNil(t, projectInfo)
 }

--- a/internal/model/project.go
+++ b/internal/model/project.go
@@ -11,6 +11,7 @@ type AliasInfo struct {
 // ProjectInfo holds configuration information
 // about a project
 type ProjectInfo struct {
-	IsActive bool        `json:"isActive"`
-	Commands []AliasInfo `json:"commands"`
+	IsActive  bool        `json:"isActive"`
+	Commands  []AliasInfo `json:"commands"`
+	Directory string      `json:"directory"`
 }

--- a/internal/pathtable/client.go
+++ b/internal/pathtable/client.go
@@ -6,6 +6,7 @@ import "github.com/JPZ13/dpm/internal/model"
 type Client interface {
 	Get(location string) (*model.ProjectInfo, error)
 	Set(path string, info *model.ProjectInfo) error
+	GetDigest(location string) (*string, error)
 }
 
 type client struct {

--- a/internal/pathtable/client.go
+++ b/internal/pathtable/client.go
@@ -6,7 +6,6 @@ import "github.com/JPZ13/dpm/internal/model"
 type Client interface {
 	Get(location string) (*model.ProjectInfo, error)
 	Set(path string, info *model.ProjectInfo) error
-	GetDigest(location string) (*string, error)
 }
 
 type client struct {

--- a/internal/pathtable/get.go
+++ b/internal/pathtable/get.go
@@ -20,14 +20,14 @@ func (c *client) Get(location string) (*model.ProjectInfo, error) {
 	}
 
 	// bubble up path checking for matches in basedirectory
-	var digest string
+	var digest *string
 	for location != "/" {
 		digest, err = c.getDigestFromPath(location)
 		if err != nil {
 			return nil, err
 		}
 
-		hasFile, _ := utils.DoesFileExist(digest)
+		hasFile, _ := utils.DoesFileExist(*digest)
 		if hasFile {
 			break
 		}
@@ -41,13 +41,13 @@ func (c *client) Get(location string) (*model.ProjectInfo, error) {
 			return nil, err
 		}
 
-		hasFile, _ := utils.DoesFileExist(digest)
+		hasFile, _ := utils.DoesFileExist(*digest)
 		if !hasFile {
 			return nil, ErrNotFound
 		}
 	}
 
-	return getProjectInfoAtPath(digest)
+	return getProjectInfoAtPath(*digest)
 }
 
 func getProjectInfoAtPath(location string) (*model.ProjectInfo, error) {
@@ -63,4 +63,9 @@ func getProjectInfoAtPath(location string) (*model.ProjectInfo, error) {
 	}
 
 	return &projectInfo, nil
+}
+
+// GetDigest gets the hashed filename used to store project config
+func (c *client) GetDigest(location string) (*string, error) {
+	return c.getDigestFromPath(location)
 }

--- a/internal/pathtable/get.go
+++ b/internal/pathtable/get.go
@@ -64,8 +64,3 @@ func getProjectInfoAtPath(location string) (*model.ProjectInfo, error) {
 
 	return &projectInfo, nil
 }
-
-// GetDigest gets the hashed filename used to store project config
-func (c *client) GetDigest(location string) (*string, error) {
-	return c.getDigestFromPath(location)
-}

--- a/internal/pathtable/set.go
+++ b/internal/pathtable/set.go
@@ -26,5 +26,5 @@ func (c *client) Set(path string, info *model.ProjectInfo) error {
 	}
 
 	// write to hashed path address in base directory
-	return utils.WriteFileBytes(digest, bytes)
+	return utils.WriteFileBytes(*digest, bytes)
 }

--- a/internal/pathtable/utils.go
+++ b/internal/pathtable/utils.go
@@ -6,14 +6,14 @@ import (
 	"github.com/JPZ13/dpm/internal/utils"
 )
 
-func (c *client) getDigestFromPath(location string) (string, error) {
+func (c *client) getDigestFromPath(location string) (*string, error) {
 	digest, err := utils.GetDigestJSONFilename(location)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	fullPath := path.Join(c.baseDirectory, digest)
-	return fullPath, nil
+	return &fullPath, nil
 }
 
 func (c *client) ensureBaseDirectory() error {


### PR DESCRIPTION
This PR:
- Removes the volume name property from the dpm yaml file
- Generates hashes based on the project directory and alias for volume name
- Prefixes the volume names with `dpm-` for easy pruning

The new volume names follow the format `dpm-[alias]-[8charater hash]`
